### PR TITLE
adding `file://` for diagnostic to work properly with stdio

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -56,7 +56,6 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -61,7 +61,7 @@ let sendUpdatedDiagnostics = () => {
     // diff
     Object.keys(filesAndErrors).forEach((file) => {
       let params: p.PublishDiagnosticsParams = {
-        uri: file,
+        uri: 'file://' + file,
         diagnostics: filesAndErrors[file],
       };
       let notification: m.NotificationMessage = {
@@ -79,7 +79,7 @@ let sendUpdatedDiagnostics = () => {
         if (filesAndErrors[file] == null) {
           // Doesn't exist in the new diagnostics. Clear this diagnostic
           let params: p.PublishDiagnosticsParams = {
-            uri: file,
+            uri:'file://' + file,
             diagnostics: [],
           };
           let notification: m.NotificationMessage = {
@@ -99,7 +99,7 @@ let deleteProjectDiagnostics = (projectRootPath: string) => {
   if (root != null) {
     root.filesWithDiagnostics.forEach((file) => {
       let params: p.PublishDiagnosticsParams = {
-        uri: file,
+        uri:'file://' + file,
         diagnostics: [],
       };
       let notification: m.NotificationMessage = {


### PR DESCRIPTION
Just to be able to make it work with nvim built in LSP
Just adding `file://` to the URI because URI does not match between the request and the response
This is a monkey patch but it works as expected, 
clone this branch and run 
```bash
npm install
npm run compile
cd analysis && make 
```
then configure your lsp like this
```lua
local lsp = require'lspconfig'
local configs = require'lspconfig/configs'
local rescriptLspPath = '~/repos/rescript-vscode/server/out/server.js'

if not lsp.rescriptlsp then
  configs.rescriptlsp = {
    default_config = {
      cmd = {'node', rescriptLspPath, '--stdio'};
      filetypes = {"rescript"};
      root_dir = lsp.util.root_pattern('bsconfig.json');
      settings = {};
    };
  }
end
lsp.rescriptlsp.setup{
  -- with your configurations
}
```
